### PR TITLE
Remove "unused" parameter from fmuls and fdivs

### DIFF
--- a/src/ppc_asm/assembler/ppc.py
+++ b/src/ppc_asm/assembler/ppc.py
@@ -731,13 +731,13 @@ def mulli(output_register: GeneralRegister, input_register: GeneralRegister, lit
     )
 
 
-def fmuls(output_register: GeneralRegister, ra: GeneralRegister, unused, rc: GeneralRegister):
+def fmuls(output_register: GeneralRegister, ra: GeneralRegister, rc: GeneralRegister):
     return Instruction.compose(
         (
             (59, 6, False),
             (output_register.number, 5, False),
             (ra.number, 5, False),
-            (unused, 5, False),
+            (0, 5, False),
             (rc.number, 5, False),
             (25, 5, False),
             (0, 1, False),
@@ -745,14 +745,14 @@ def fmuls(output_register: GeneralRegister, ra: GeneralRegister, unused, rc: Gen
     )
 
 
-def fdivs(output_register: GeneralRegister, ra: GeneralRegister, rb: GeneralRegister, unused):
+def fdivs(output_register: GeneralRegister, ra: GeneralRegister, rb: GeneralRegister):
     return Instruction.compose(
         (
             (59, 6, False),
             (output_register.number, 5, False),
             (ra.number, 5, False),
             (rb.number, 5, False),
-            (unused, 5, False),
+            (0, 5, False),
             (18, 5, False),
             (0, 1, False),
         )


### PR DESCRIPTION
Remove "unused" parameter from fmuls and fdivs

Formerly, calling fmuls or fdivs would require passing in a `0` for `unused`:
`fmuls(output_register: GeneralRegister, ra: GeneralRegister, unused, rc: GeneralRegister)`
`fdivs(output_register: GeneralRegister, ra: GeneralRegister, rb: GeneralRegister, unused)`

This PR removes the `unused` parameter:
`fmuls(output_register: GeneralRegister, ra: GeneralRegister, rc: GeneralRegister)`
`fdivs(output_register: GeneralRegister, ra: GeneralRegister, rb: GeneralRegister)`